### PR TITLE
7651 update request requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ cement==2.10.2
 lockfile==0.12.2
 pymongo==3.6.1
 python-dateutil==2.7.*
-requests==2.22.*
+requests>=2.22.0
 ujson==1.35

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         "lockfile==0.12.2",
         "pymongo==3.6.1",
         "python-dateutil==2.7.*",
-        "requests==2.22.*",
+        "requests>=2.22.0,<2.28",
         "ujson==1.35",
     ],
     classifiers=[


### PR DESCRIPTION
Update requests requirements to be more lax (up to versions that still support python 3.6), no breaking changes with this update.

# Testing

run `python manage.py ap_general_report --election-date 2024-11-05` it should run successfully.


If you get 403 error's make sure your AP_API_KEY matches the same key as AP_ELECTIONS_API_KEY

# Push-time steps
Because our `requirements.txt` in `nj-cms` references the default branch of this repo, it is important to bump the version of this library in both `__init__.py` and `setup.py` so that `pip` can identify the changes and knows to pull new code. Otherwise, Jenkins will likely fail to get the latest code and the `pip install` step at push time can silently fail to retrieve the latest code from this repo as well.