### PR TITLE
7777 upgrade python-dateutil==2.9.*

### DIFF
--- a/elex/__init__.py
+++ b/elex/__init__.py
@@ -6,7 +6,7 @@ from cachecontrol import CacheControl
 from cachecontrol.caches import FileCache
 from elex.cachecontrol_heuristics import EtagOnlyCache
 
-__version__ = "2.4.5"
+__version__ = "2.4.6"
 _DEFAULT_CACHE_DIRECTORY = os.path.join(tempfile.gettempdir(), "elex-cache")
 
 API_KEY = os.environ.get("AP_API_KEY", None)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ CacheControl==0.12.*
 cement==2.10.2
 lockfile==0.12.2
 pymongo==3.6.1
-python-dateutil==2.7.*
+python-dateutil==2.9.*
 requests>=2.22.0
 ujson==1.35

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def read(filename):
 
 setup(
     name="elex",
-    version="2.4.5",
+    version="2.4.6",
     author="Jeremy Bowers, David Eads",
     author_email="jeremy.bowers@nytimes.com, davideads@gmail.com",
     url="https://github.com/newsdev/elex",


### PR DESCRIPTION
## Ticket #7777

Upgrade  python-dateutil to version 2..9.*

Bump up version to 2.4.6

## Testing
- on local run `docker-compose exec backend pip install git+https://github.com/NationalJournal/elex.git@7777-upgrade-python-dateutil==2.9` to update elex to this branch.
- run `docker-compose exec backend elex results 2016-03-01 > results.csv` observe no errors and inspect results.csv for data